### PR TITLE
Solve the position and size issues when getting the tile map and cities map.

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,8 @@
 'use strict'
 
+const vmapSize = 18;
+const mapSize = 17.28;
+const tileSize = 1.92;
 var grid = loadSettings();
 let debug = !!new URL(window.location.href).searchParams.get('debug');
 let debugElements = document.getElementsByClassName('debug');
@@ -30,7 +33,7 @@ map.on('load', function () {
 
     map.addSource('grid', {
         'type': 'geojson',
-        'data': getGrid(grid.lng, grid.lat, 18)
+        'data': getGrid(grid.lng, grid.lat, vmapSize)
     });
 
     map.addLayer({
@@ -46,7 +49,7 @@ map.on('load', function () {
 
     map.addSource('playable', {
         'type': 'geojson',
-        'data': getGrid(grid.lng, grid.lat, 10)
+        'data': getGrid(grid.lng, grid.lat, vmapSize / 9 * 5)
     });
 
     map.addLayer({
@@ -62,7 +65,7 @@ map.on('load', function () {
 
     map.addSource('start', {
         'type': 'geojson',
-        'data': getGrid(grid.lng, grid.lat, 2)
+        'data': getGrid(grid.lng, grid.lat, vmapSize / 9)
     });
 
     map.addLayer({
@@ -177,7 +180,7 @@ map.on('click', function (e) {
     grid.lng = e.lngLat.lng;
     grid.lat = e.lngLat.lat;
 
-    setGrid(grid.lng, grid.lat, 18);
+    setGrid(grid.lng, grid.lat, vmapSize);
     map.panTo(new mapboxgl.LngLat(grid.lng, grid.lat));
     saveSettings();
     hideDebugLayer();
@@ -192,7 +195,7 @@ geocoder.on('result', function (query) {
     grid.lng = query.result.center[0];
     grid.lat = query.result.center[1];
 
-    setGrid(grid.lng, grid.lat, 18);
+    setGrid(grid.lng, grid.lat, vmapSize);
     map.setZoom(10.2);
 
     saveSettings();
@@ -203,13 +206,13 @@ geocoder.on('result', function (query) {
 function onMove(e) {
     grid.lng = e.lngLat.lng;
     grid.lat = e.lngLat.lat;
-    setGrid(e.lngLat.lng, e.lngLat.lat, 18);
+    setGrid(e.lngLat.lng, e.lngLat.lat, vmapSize);
 }
 
 function onUp(e) {
     grid.lng = e.lngLat.lng;
     grid.lat = e.lngLat.lat;
-    setGrid(e.lngLat.lng, e.lngLat.lat, 18);
+    setGrid(e.lngLat.lng, e.lngLat.lat, vmapSize);
 
     // Unbind mouse/touch events
     map.off('mousemove', onMove);
@@ -262,13 +265,13 @@ function hideDebugLayer() {
 }
 
 function setGrid(lng, lat, size) {
-    map.getSource('grid').setData(getGrid(lng, lat, size - 0.1));
+    map.getSource('grid').setData(getGrid(lng, lat, size));
     map.getSource('start').setData(getGrid(lng, lat, size / 9));
-    map.getSource('playable').setData(getGrid(lng, lat, size - 8));
+    map.getSource('playable').setData(getGrid(lng, lat, size / 9 * 5));
     grid.zoom = map.getZoom();
 }
 
-function getExtent(lng, lat, size = 18) {
+function getExtent(lng, lat, size = vmapSize) {
     let dist = Math.sqrt(2 * Math.pow(size / 2, 2));
     let point = turf.point([lng, lat]);
     let topleft = turf.destination(point, dist, -45, { units: 'kilometers' }).geometry.coordinates;
@@ -278,7 +281,7 @@ function getExtent(lng, lat, size = 18) {
 
 function getGrid(lng, lat, size) {
     let extent = getExtent(lng, lat, size);
-    return turf.squareGrid([extent.topleft[0], extent.topleft[1], extent.bottomright[0], extent.bottomright[1]], 2 - 0.02, { units: 'kilometers' });
+    return turf.squareGrid([extent.topleft[0], extent.topleft[1], extent.bottomright[0], extent.bottomright[1]], tileSize, { units: 'kilometers' });
 }
 
 function loadSettings() {

--- a/src/app.js
+++ b/src/app.js
@@ -121,7 +121,8 @@ map.on('load', function () {
     if (debug) {
         map.addSource('debug', {
             'type': 'geojson',
-            'data': turf.squareGrid([0, 0, 0, 0], 2, { units: 'kilometers' })
+            // 'data': turf.squareGrid([0, 0, 0, 0], tileSize, { units: 'kilometers' })
+            'data': turf.bboxPolygon(turf.bbox(turf.lineString([0, 0], [0, 0])))
         });
 
         map.addLayer({
@@ -129,7 +130,7 @@ map.on('load', function () {
             'type': 'line',
             'source': 'debug',
             'paint': {
-                'line-color': 'orangered',
+                'line-width': 1
                 'line-width': 0.5
             },
             'layout': {
@@ -391,8 +392,8 @@ function getHeightmap(mode = 0) {
 
     // debug: update the download area
     if (debug) {
-        map.setLayoutProperty('debugLayer', 'visibility', 'visible');
-        let debugGrid = turf.squareGrid([tileLng, tileLat, tileLng2, tileLat2], distance / 4 - 0.05, { units: 'kilometers' });
+        let line = turf.lineString([[tileLng, tileLat], [tileLng2, tileLat2]]);  
+        map.getSource('debug').setData(turf.bboxPolygon(turf.bbox(line)));
         map.getSource('debug').setData(debugGrid);
     }
 

--- a/src/app.js
+++ b/src/app.js
@@ -130,8 +130,8 @@ map.on('load', function () {
             'type': 'line',
             'source': 'debug',
             'paint': {
+                'line-color': 'orangered',
                 'line-width': 1
-                'line-width': 0.5
             },
             'layout': {
                 'visibility': 'none'

--- a/src/app.js
+++ b/src/app.js
@@ -641,14 +641,11 @@ function toCitiesmap(heightmap, xOffset, yOffset) {
 
     let depthUnits = scope.depth / 0.015625;
 
-    // iterate over the heightmap
-    for (let y = 0; y < 2048; y++) {
-        if (y < yOffset || y > 1081 + yOffset) continue;
-        for (let x = 0; x < 2048; x++) {
-            if (x < xOffset || x > 1081 + xOffset) continue;
+    for (let y = 0; y < 1081; y++) {
+        for (let x = 0; x < 1081; x++) {    
 
             // scale the height, taking seaLevel and scale into account 
-            let height = Math.round((heightmap[y][x] / 10 - scope.seaLevel) / 0.015625 * parseFloat(scope.heightScale) / 100);
+            let height = Math.round((heightmap[y + yOffset][x + xOffset] / 10 - scope.seaLevel) / 0.015625 * parseFloat(scope.heightScale) / 100);
 
             // we are here at cities scale: 0xFFFF = 65535 => 1024 meters
             if (document.getElementById('landOnly').checked) {
@@ -659,12 +656,12 @@ function toCitiesmap(heightmap, xOffset, yOffset) {
             }
 
             // make sure water always flows to the west
-            //height = height + (1081 - x - xOffset);
+            // height = height + (1081 - x - xOffset);
 
             if (height > 65535) height = 65535;
 
             // calculate index in image
-            let index = (y - yOffset) * 1081 * 2 + (x - xOffset) * 2;
+            let index = y * 1081 * 2 + x * 2;
 
             // cities used hi/low 16 bit
             citiesmap[index + 0] = height >> 8;
@@ -679,9 +676,8 @@ function toCitiesmap(heightmap, xOffset, yOffset) {
     citiesmap[3] = 0;
 
     // log the correct bounding rect to the console
-    let bounds = getExtent(grid.lng, grid.lat, 18);
+    let bounds = getExtent(grid.lng, grid.lat, mapSize);
     console.log(bounds.topleft[0], bounds.topleft[1], bounds.bottomright[0], bounds.bottomright[1]);
-
 
     return citiesmap;
 }

--- a/src/app.js
+++ b/src/app.js
@@ -3,7 +3,9 @@
 const vmapSize = 18;
 const mapSize = 17.28;
 const tileSize = 1.92;
+
 var grid = loadSettings();
+
 let debug = !!new URL(window.location.href).searchParams.get('debug');
 let debugElements = document.getElementsByClassName('debug');
 if (debug) while (debugElements.length > 0) {
@@ -115,7 +117,6 @@ map.on('load', function () {
             'fill-outline-color': 'rgba(33,33,255, 1)'
         }
     });
-
 
     // debug: area that is downloaded
     if (debug) {
@@ -347,7 +348,6 @@ function updateInfopanel() {
     document.getElementById('maxh').innerHTML = grid.maxHeight;
 }
 
-
 function zoomIn() {
     map.zoomIn();
 }
@@ -375,7 +375,7 @@ function getHeightmap(mode = 0) {
     let tileCnt = Math.max(x2 - x + 1, y2 - y + 1);
 
     let iCnt = tileCnt;
-    
+
     // fixed in high latitudes: adjusted the tile count to 6 or less
     // because Terrain-RGB tile is different in size at latitude
     // don't need too many tiles
@@ -395,7 +395,7 @@ function getHeightmap(mode = 0) {
         zoom = z;
         tileCnt = tc;
     }
-    
+
     let tileLng = tile2long(x, zoom);
     let tileLat = tile2lat(y, zoom);
 
@@ -414,7 +414,7 @@ function getHeightmap(mode = 0) {
 
     if (debug) {
         map.setLayoutProperty('debugLayer', 'visibility', 'visible');
-        let line = turf.lineString([[tileLng, tileLat], [tileLng2, tileLat2]]);  
+        let line = turf.lineString([[tileLng, tileLat], [tileLng2, tileLat2]]);
         map.getSource('debug').setData(turf.bboxPolygon(turf.bbox(line)));
     }
 
@@ -437,7 +437,7 @@ function getHeightmap(mode = 0) {
         if (isDownloadComplete(tiles)) {
             clearInterval(timer);
             let canvas, url;
-        
+
             // heightmap size corresponds to 1081px map size
             let heightmap = toHeightmap(tiles, distance);
 
@@ -523,10 +523,10 @@ function toHeightmap(tiles, distance) {
 
     // bilinear interpolation
     let hmIndex = Array(hmSize);
-    
-    for (let i = 0; i < hmSize; i++) {hmIndex[i] = i / r}   
+
+    for (let i = 0; i < hmSize; i++) {hmIndex[i] = i / r}
     for (let i = 0; i < (hmSize - 1); i++) {
-        for (let j = 0; j < (hmSize - 1); j++) {    
+        for (let j = 0; j < (hmSize - 1); j++) {
             let y0 = Math.floor(hmIndex[i]);
             let x0 = Math.floor(hmIndex[j]);
             let y1 = y0 + 1;
@@ -534,7 +534,7 @@ function toHeightmap(tiles, distance) {
             let dy = hmIndex[i] - y0;
             let dx = hmIndex[j] - x0;
             heightmap[i][j] = Math.round((1 - dx) * (1 - dy) * srcMap[y0][x0] + dx * (1 - dy) * srcMap[y0][x1] + (1 - dx) * dy * srcMap[y1][x0] + dx * dy * srcMap[y1][x1]);
-        }    
+        }
     }
     for (let i = 0; i < hmSize; i++) {heightmap[i][hmSize - 1] = srcMap[i][hmSize - 1]}
     for (let j = 0; j < hmSize; j++) {heightmap[hmSize - 1][j] = srcMap[hmSize - 1][j]}
@@ -545,7 +545,7 @@ function toHeightmap(tiles, distance) {
 function toTerrainRGB(heightmap) {
     let canvas = document.createElement('canvas');
     const ctx = canvas.getContext('2d');
-    
+
     canvas.width = heightmap.length;
     canvas.height = heightmap.length;
 
@@ -582,7 +582,7 @@ function toCanvas(heightmap, xOffset, yOffset) {
 
     // iterate over the heightmap, ignore the sealevel rise (for now)
     for (let y = 0; y < 1081; y++) {
-        for (let x = 0; x < 1081; x++) {    
+        for (let x = 0; x < 1081; x++) {
 
             // scale the height, an integer in 0.1 meter resolution
             // to 4 meters resolution, max is 1023m.
@@ -608,7 +608,7 @@ function toCanvas(heightmap, xOffset, yOffset) {
         }
     }
 
-    if (document.getElementById('drawGrid').checked) { 
+    if (document.getElementById('drawGrid').checked) {
         // draw a grid on the image
         for (let y = 1; y < 1081; y++) {
             for (let x = 1; x < 1081; x++) {
@@ -642,9 +642,9 @@ function toCitiesmap(heightmap, xOffset, yOffset) {
     let depthUnits = scope.depth / 0.015625;
 
     for (let y = 0; y < 1081; y++) {
-        for (let x = 0; x < 1081; x++) {    
+        for (let x = 0; x < 1081; x++) {
 
-            // scale the height, taking seaLevel and scale into account 
+            // scale the height, taking seaLevel and scale into account
             let height = Math.round((heightmap[y + yOffset][x + xOffset] / 10 - scope.seaLevel) / 0.015625 * parseFloat(scope.heightScale) / 100);
 
             // we are here at cities scale: 0xFFFF = 65535 => 1024 meters

--- a/src/app.js
+++ b/src/app.js
@@ -542,20 +542,32 @@ function toHeightmap(tiles, distance) {
     return heightmap;
 }
 
-function tilesToCanvas(tiles) {
+function toTerrainRGB(heightmap) {
     let canvas = document.createElement('canvas');
-    canvas.width = 2048;
-    canvas.height = 2048;
-
     const ctx = canvas.getContext('2d');
-    const data = ctx.createImageData(512, 512);
+    
+    canvas.width = heightmap.length;
+    canvas.height = heightmap.length;
 
-    for (let i = 0; i < 4; i++) {
-        for (let j = 0; j < 4; j++) {
-            tiles[i][j].copyToImageData(data, tiles[i][j].decodePixels());
-            ctx.putImageData(data, i * 512, j * 512);
+    let img = ctx.getImageData(0, 0, canvas.width, canvas.height);
+
+    for (let y = 0; y < canvas.height; y++) {
+        for (let x = 0; x < canvas.width; x++) {
+            let r = Math.floor((Math.floor((heightmap[y][x] + 100000) / 256)) / 256);
+            let g = (Math.floor((heightmap[y][x] + 100000) / 256)) % 256;
+            let b = (heightmap[y][x] + 100000) % 256;
+
+            let index = y * canvas.width * 4 + x * 4;
+
+            // create pixel
+            img.data[index + 0] = r;
+            img.data[index + 1] = g;
+            img.data[index + 2] = b;
+            img.data[index + 3] = 255;
         }
     }
+
+    ctx.putImageData(img, 0, 0);
 
     return canvas;
 }

--- a/src/app.js
+++ b/src/app.js
@@ -572,7 +572,7 @@ function toTerrainRGB(heightmap) {
     return canvas;
 }
 
-function heightmaptilesToCanvas(heightmap, xOffset, yOffset) {
+function toCanvas(heightmap, xOffset, yOffset) {
     let canvas = document.createElement('canvas');
     canvas.width = 1081;
     canvas.height = 1081;
@@ -581,14 +581,12 @@ function heightmaptilesToCanvas(heightmap, xOffset, yOffset) {
     let img = ctx.getImageData(0, 0, 1081, 1081);
 
     // iterate over the heightmap, ignore the sealevel rise (for now)
-    for (let y = 0; y < 2048; y++) {
-        if (y < yOffset || y > 1081 + yOffset) continue;
-        for (let x = 0; x < 2048; x++) {
-            if (x < xOffset || x > 1081 + xOffset) continue;
+    for (let y = 0; y < 1081; y++) {
+        for (let x = 0; x < 1081; x++) {    
 
             // scale the height, an integer in 0.1 meter resolution
             // to 4 meters resolution, max is 1023m.
-            let h = Math.floor((heightmap[y][x] / 10 - scope.seaLevel) / 4 * parseFloat(scope.heightScale) / 100);
+            let h = Math.floor((heightmap[y + yOffset][x + xOffset] / 10 - scope.seaLevel) / 4 * parseFloat(scope.heightScale) / 100);
 
             // we are here at meters scale
             if (document.getElementById('landOnly').checked) {
@@ -600,16 +598,16 @@ function heightmaptilesToCanvas(heightmap, xOffset, yOffset) {
             h = Math.min(255, h);
 
             // calculate index in image
-            let index = (y - yOffset) * 1081 * 4 + (x - xOffset) * 4;
+            let index = y * 1081 * 4 + x * 4;
 
             // create pixel
-            img.data[index + 0] = h; // heightmap[y, x] / 10;  // red
+            img.data[index + 0] = h;    // heightmap[y, x] / 10;  // red
             img.data[index + 1] = h;    // green
             img.data[index + 2] = h;    // blue
-            img.data[index + 3] = 255;  //alpha, 255 is full opaque
+            img.data[index + 3] = 255;  // alpha, 255 is full opaque
         }
     }
-    
+
     if (document.getElementById('drawGrid').checked) { 
         // draw a grid on the image
         for (let y = 1; y < 1081; y++) {


### PR DESCRIPTION
### Issue
[Notification] Map size #3

### Contents
1. The cities map size was 18km.
2. Grid display issue (sometimes not 9x9).
3. We were not able to cover the area of cities map in the high latitude zone, because the tile count and zoom values we were getting were fixed.
4. There was a issue with the calculation of getting the cities map.

### Revision details

1. Fixed map size to 17.28km.
2. The specification of "squareGrid" is that if the range cannot be completely divided by cellSide, it will be displayed in the center with a small count of cells.  This specification and the difference in scale depending on latitude caused problems with the grid display. So I set up an 18km size virtual map for display and fixed it so that it always displays 9x9.
3. In theory, the tile count required for the cities map increases with latitude, so I calculated the required tile count from the top left and bottom right points of the cities map. Additionally, I lowered the zoom value when the tile count was high, to reduce the increase in tile pixels as the tile count increased since the size of the cities map is fixed at 1081px. This action also has the purpose of reducing the load.
4. Resample to get the same "1px=15.985m" as the cities map, because the distance per pixel of a tile depends on its position. Resample using Bilinear interpolation. Then cut out the area of the cities map from the tile map.